### PR TITLE
Added xxNew calls inspired by RTX5

### DIFF
--- a/CMSIS/RTOS2/FreeRTOS/FreeRTOS.scvd
+++ b/CMSIS/RTOS2/FreeRTOS/FreeRTOS.scvd
@@ -155,6 +155,43 @@
       <var name="Name" type="uint8_t" info="Timer name string" size="64"/>
     </typedef>
 
+    <typedef name="osThreadAttr_t" info="" size="36">
+      <member name="name"       type="uint32_t" offset="0"  info="name of the thread (type is const char *)"/>
+      <member name="attr_bits"  type="uint32_t" offset="4"  info="attribute bits"/>
+      <member name="cb_mem"     type="uint32_t" offset="8"  info="memory for control block (type is void *)"/>
+      <member name="cb_size"    type="uint32_t" offset="12" info="size of provided memory for control block"/>
+      <member name="stack_mem"  type="uint32_t" offset="16" info="memory for stack (type is void *)"/>
+      <member name="stack_size" type="uint32_t" offset="20" info="size of stack"/>
+      <member name="priority"   type="uint32_t" offset="24" info="initial thread priority (type is osPriority_t)"/>
+      <member name="tz_module"  type="uint32_t" offset="28" info="TrustZone module identifier (type is TZ_ModuleId_t)"/>
+      <member name="reserved"   type="uint32_t" offset="32" info="reserved (must be 0)"/>
+    </typedef>
+
+    <!-- Attributes structure for timer -->
+    <typedef name="osTimerAttr_t" info="" size="16">
+      <member name="name"      type="uint32_t" offset="0"  info="name of the timer (type is const char *)"/>
+      <member name="attr_bits" type="uint32_t" offset="4"  info="attribute bits"/>
+      <member name="cb_mem"    type="uint32_t" offset="8"  info="memory for control block (type is void *)"/>
+      <member name="cb_size"   type="uint32_t" offset="12" info="size of provided memory for control block"/>
+    </typedef>
+
+    <!-- Attributes structure for event flags -->
+    <typedef name="osEventFlagsAttr_t" info="" size="16">
+      <member name="name"      type="uint32_t" offset="0"  info="name of the event flags (type is const char *)"/>
+      <member name="attr_bits" type="uint32_t" offset="4"  info="attribute bits"/>
+      <member name="cb_mem"    type="uint32_t" offset="8"  info="memory for control block (type is void *)"/>
+      <member name="cb_size"   type="uint32_t" offset="12" info="size of provided memory for control block"/>
+    </typedef>
+    
+    <!-- Attributes structure for message queue -->
+    <typedef name="osMessageQueueAttr_t" info="" size="24">
+      <member name="name"      type="uint32_t" offset="0"  info="name of the semaphore (type is const char *)"/>
+      <member name="attr_bits" type="uint32_t" offset="4"  info="attribute bits"/>
+      <member name="cb_mem"    type="uint32_t" offset="8"  info="memory for control block (type is void *)"/>
+      <member name="cb_size"   type="uint32_t" offset="12" info="size of provided memory for control block"/>
+      <member name="mq_mem"    type="uint32_t" offset="16" info="memory for data storage (type is void *)"/>
+      <member name="mq_size"   type="uint32_t" offset="20" info="size of provided memory for data storage"/>
+    </typedef>
   </typedefs>
 
   <objects>
@@ -526,6 +563,8 @@
     <event id="0xF000 + 0x17" level="Op"     property="TaskNotify"                value="xTaskToNotify=%x[val1], ulValue=%x[val2], eAction=%x[val3], ulNotifiedValue=%x[val4]" info=""/>
     <event id="0xF000 + 0x18" level="Op"     property="TaskNotifyFromIsr"         value="xTaskToNotify=%x[val1], ulValue=%x[val2], eAction=%x[val3], ulNotifiedValue=%x[val4]" info=""/>
     <event id="0xF000 + 0x19" level="Op"     property="TaskNotifyGiveFromIsr"     value="xTaskToNotify=%x[val1], ulNotifiedValue=%x[val2]" info=""/>
+    <event id="0xF000 + 0x30" level="API"    property="TaskNew"                   value="func=%S[val1], argument=%x[val2], attr=%x[val3]" info=""/>
+    <event id="0xF000 + 0x31" level="Detail" property="TaskNew"                   value="name=%x[val1.name], attr_bits=%x[val1.attr_bits], cb_mem=%x[val1.cb_mem], cb_size=%d[val1.cb_size], stack_mem=%x[val1.stack_mem], stack_size=%d[val1.stack_size], priority=%E[val7, rtx_th_priority:id]" val1="osThreadAttr_t" info=""/>
 
     <event id="0xF100 + 0x00" level="Op"    property="QueueCreate"                   value="pxQueue=%x[val1]" info=""/>
     <event id="0xF100 + 0x01" level="Error" property="QueueCreateFailed"             value="ucQueueType=%x[val1]" info=""/>
@@ -552,6 +591,8 @@
     <event id="0xF100 + 0x16" level="Op"    property="QueueRegistryAdd"              value="pxQueue=%x[val1], pcQueueName=%x[val2]" info=""/>
     <event id="0xF100 + 0x17" level="Op"    property="BlockingOnQueueReceive"        value="pxQueue=%x[val1]" info=""/>
     <event id="0xF100 + 0x18" level="Op"    property="BlockingOnQueueSend"           value="pxQueue=%x[val1]" info=""/>
+    <event id="0xF100 + 0x30" level="API"   property="QueueNew"                      value="msg_count=%d[val1], msg_size=%d[val2], attr=%x[val3]" info=""/>
+    <event id="0xF100 + 0x31" level="Detail" property="QueueNew"                     value="name=%x[val1.name], attr_bits=%x[val1.attr_bits], cb_mem=%x[val1.cb_mem], cb_size=%d[val1.cb_size], mq_mem=%x[val1.mq_mem], mq_size=%d[val1.mq_size]" val1="osMessageQueueAttr_t" info=""/>
 
     <event id="0xF200 + 0x00" level="Op"    property="TimerCreate"          value="pxNewTimer=%x[val1]" info=""/>
     <event id="0xF200 + 0x01" level="Error" property="TimerCreateFailed"    value="" info=""/>
@@ -560,6 +601,8 @@
     <event id="0xF200 + 0x04" level="Op"    property="TimerExpired"         value="pxTimer=%x[val1]" info=""/>
     <event id="0xF200 + 0x05" level="Op"    property="PendFuncCall"         value="pxFunctionToPend=%x[val1], pvParameter1=%x[val2], ulParameter2=%x[val3], xReturn=%x[val4]" info=""/>
     <event id="0xF200 + 0x06" level="Op"    property="PendFuncCallFromIsr"  value="pxFunctionToPend=%x[val1], pvParameter1=%x[val2], ulParameter2=%x[val3], xReturn=%x[val4]" info=""/>
+    <event id="0xF200 + 0x30" level="API"   property="TimerNew"             value="func=%S[val1], type=%E[val2, osRtxTimer_t:type], argument=%x[val3], attr=%x[val4]" info=""/>
+    <event id="0xF200 + 0x31" level="Detail" property="TimerNew"            value="name=%x[val1.name], attr_bits=%x[val1.attr_bits], cb_mem=%x[val1.cb_mem], cb_size=%d[val1.cb_size]" val1="osTimerAttr_t" info=""/>
 
     <event id="0xF300 + 0x00" level="Op"    property="EventGroupCreate"           value="pxEventGroup=%x[val1]" info=""/>
     <event id="0xF300 + 0x01" level="Error" property="EventGroupCreateFailed"     value="" info=""/>
@@ -572,6 +615,8 @@
     <event id="0xF300 + 0x08" level="Op"    property="EventGroupSetBits"          value="pxEventGroup=%x[val1], uxBitsToSet=%x[val2]" info=""/>
     <event id="0xF300 + 0x09" level="Op"    property="EventGroupSetBitsFromIsr"   value="pxEventGroup=%x[val1], uxBitsToSet=%x[val2]" info=""/>
     <event id="0xF300 + 0x0A" level="Op"    property="EventGroupDelete"           value="pxEventGroup=%x[val1]" info=""/>
+    <event id="0xF300 + 0x30" level="API"   property="EventGroupNew"              value="attr=%x[val1]" info=""/>
+    <event id="0xF300 + 0x31" level="Detail" property="EventGroupNew"             value="name=%x[val1.name], attr_bits=%x[val1.attr_bits], cb_mem=%x[val1.cb_mem], cb_size=%d[val1.cb_size]" val1="osEventFlagsAttr_t" info=""/>
 
     <event id="0xF400 + 0x00" level="Op"    property="Malloc" value="pvAddress=%x[val1], uiSize=%d[val2]" info=""/>
     <event id="0xF400 + 0x01" level="Op"    property="Free"   value="pvAddress=%x[val1], uiSize=%d[val2]" info=""/>

--- a/CMSIS/RTOS2/FreeRTOS/Include/freertos_evr.h
+++ b/CMSIS/RTOS2/FreeRTOS/Include/freertos_evr.h
@@ -27,6 +27,7 @@
 #include <stdint.h>
 
 #include "RTE_Components.h"
+#include "cmsis_os2.h"                  // ::CMSIS:RTOS2
 
 #if !defined(RTE_Compiler_EventRecorder)
   /* Disable debug events if Event Recorder is not used */
@@ -41,15 +42,6 @@
 #define Timer_t          void*
 #define PendedFunction_t void*
 #define EventGroup_t     void*
-
-/* Temporarily define CMSIS-OS2 object types */
-#define osThreadFunc_t       void*
-#define osThreadAttr_t       void*
-#define osMessageQueueAttr_t void*
-#define osTimerFunc_t        void*
-#define osTimerType_t        void*
-#define osTimerAttr_t        void*
-#define osEventFlagsAttr_t   void*
 
 /**
 */

--- a/CMSIS/RTOS2/FreeRTOS/Include/freertos_evr.h
+++ b/CMSIS/RTOS2/FreeRTOS/Include/freertos_evr.h
@@ -42,6 +42,19 @@
 #define PendedFunction_t void*
 #define EventGroup_t     void*
 
+/* Temporarily define CMSIS-OS2 object types */
+#define osThreadFunc_t       void*
+#define osThreadAttr_t       void*
+#define osMessageQueueAttr_t void*
+#define osTimerFunc_t        void*
+#define osTimerType_t        void*
+#define osTimerAttr_t        void*
+#define osEventFlagsAttr_t   void*
+
+/**
+*/
+extern void EvrFreeRTOSTasks_TaskNew(osThreadFunc_t func, void *argument, const osThreadAttr_t *attr);
+
 /**
   \brief  Event on successful task create (Op)
   \param[in]  pxNewTCB          pointer to task handle.
@@ -208,6 +221,10 @@ extern void EvrFreeRTOSTasks_TaskNotifyFromIsr (TCB_t xTaskToNotify, uint32_t ul
 extern void EvrFreeRTOSTasks_TaskNotifyGiveFromIsr (TCB_t xTaskToNotify, uint32_t ulNotifiedValue);
 
 /**
+*/
+extern void EvrFreeRTOSQueue_QueueNew (uint32_t msg_count, uint32_t msg_size, const osMessageQueueAttr_t *attr);
+
+/**
   \brief  Event on successful queue create (Op)
   \param[in]  pxQueue           pointer to mutex object handle.
 */
@@ -357,6 +374,10 @@ extern void EvrFreeRTOSQueue_BlockingOnQueueReceive (Queue_t pxQueue);
 extern void EvrFreeRTOSQueue_BlockingOnQueueSend (Queue_t pxQueue);
 
 /**
+*/
+extern void EvrFreeRTOSTimers_TimerNew(osTimerFunc_t func, osTimerType_t type, void *argument, const osTimerAttr_t *attr);
+
+/**
   \brief  Event on successful timer object create (Op)
   \param[in]  pxNewTimer        pointer to timer object handle.
 */
@@ -407,6 +428,10 @@ extern void EvrFreeRTOSTimers_PendFuncCall (PendedFunction_t pxFunctionToPend, v
   \param[in]  xReturn           return value.
 */
 extern void EvrFreeRTOSTimers_PendFuncCallFromIsr (PendedFunction_t pxFunctionToPend, void *pvParameter1, uint32_t ulParameter2, uint32_t xReturn);
+
+/**
+*/
+extern void EvrFreeRTOSEventGroups_EventGroupNew(const osEventFlagsAttr_t *attr);
 
 /**
   \brief  Event on successful event groups object create (Op)

--- a/CMSIS/RTOS2/FreeRTOS/Source/cmsis_os2.c
+++ b/CMSIS/RTOS2/FreeRTOS/Source/cmsis_os2.c
@@ -27,6 +27,7 @@
 #include "cmsis_os2.h"                  // ::CMSIS:RTOS2
 #include "cmsis_compiler.h"
 
+#include "freertos_evr.h"
 #include "FreeRTOS.h"                   // ARM.FreeRTOS::RTOS:Core
 #include "task.h"                       // ARM.FreeRTOS::RTOS:Core
 #include "event_groups.h"               // ARM.FreeRTOS::RTOS:Event Groups
@@ -357,6 +358,8 @@ osThreadId_t osThreadNew (osThreadFunc_t func, void *argument, const osThreadAtt
   int32_t mem;
 
   h = NULL;
+
+  EvrFreeRTOSTasks_TaskNew(func, argument, attr);
 
   if (!IS_IRQ() && (func != NULL)) {
     stack = configMINIMAL_STACK_SIZE;
@@ -803,6 +806,8 @@ osTimerId_t osTimerNew (osTimerFunc_t func, osTimerType_t type, void *argument, 
 
   h = NULL;
 
+  EvrFreeRTOSTimers_TimerNew(func, type, argument, attr);
+
   if (!IS_IRQ() && (func != NULL)) {
     /* Allocate memory to store callback function and argument */
     callb = pvPortMalloc (sizeof(TimerCallback_t));
@@ -956,6 +961,8 @@ osEventFlagsId_t osEventFlagsNew (const osEventFlagsAttr_t *attr) {
   int32_t mem;
 
   h = NULL;
+
+  EvrFreeRTOSEventGroups_EventGroupNew(attr);
 
   if (!IS_IRQ()) {
     mem = -1;
@@ -1445,6 +1452,8 @@ osMessageQueueId_t osMessageQueueNew (uint32_t msg_count, uint32_t msg_size, con
   int32_t mem;
 
   h = NULL;
+
+  EvrFreeRTOSQueue_QueueNew(msg_count, msg_size, attr);
 
   if (!IS_IRQ() && (msg_count > 0U) && (msg_size > 0U)) {
     mem = -1;

--- a/CMSIS/RTOS2/FreeRTOS/Source/freertos_evr.c
+++ b/CMSIS/RTOS2/FreeRTOS/Source/freertos_evr.c
@@ -66,6 +66,8 @@
 #define EvtFreeRTOSTasks_TaskNotify                       EventID(EventLevelOp,     EvtFreeRTOSTasksNo, 0x17U)
 #define EvtFreeRTOSTasks_TaskNotifyFromIsr                EventID(EventLevelOp,     EvtFreeRTOSTasksNo, 0x18U)
 #define EvtFreeRTOSTasks_TaskNotifyGiveFromIsr            EventID(EventLevelOp,     EvtFreeRTOSTasksNo, 0x19U)
+#define EvtFreeRTOSTasks_TaskNew                          EventID(EventLevelAPI,    EvtFreeRTOSTasksNo, 0x30U)
+#define EvtFreeRTOSTasks_TaskNew_Detail                   EventID(EventLevelDetail, EvtFreeRTOSTasksNo, 0x31U)
 
 /* Event IDs for "FreeRTOS Queue" */
 #define EvtFreeRTOSQueue_QueueCreate                      EventID(EventLevelOp,     EvtFreeRTOSQueueNo, 0x00U)
@@ -93,6 +95,8 @@
 #define EvtFreeRTOSQueue_QueueRegistryAdd                 EventID(EventLevelOp,     EvtFreeRTOSQueueNo, 0x16U)
 #define EvtFreeRTOSQueue_BlockingOnQueueReceive           EventID(EventLevelOp,     EvtFreeRTOSQueueNo, 0x17U)
 #define EvtFreeRTOSQueue_BlockingOnQueueSend              EventID(EventLevelOp,     EvtFreeRTOSQueueNo, 0x18U)
+#define EvtFreeRTOSQueue_QueueNew                         EventID(EventLevelAPI,    EvtFreeRTOSQueueNo, 0x30U)
+#define EvtFreeRTOSQueue_QueueNew_Detail                  EventID(EventLevelDetail, EvtFreeRTOSQueueNo, 0x31U)
 
 /* Event IDs for "FreeRTOS Timers" */
 #define EvtFreeRTOSTimers_TimerCreate                     EventID(EventLevelOp,     EvtFreeRTOSTimersNo, 0x00U)
@@ -102,6 +106,8 @@
 #define EvtFreeRTOSTimers_TimerExpired                    EventID(EventLevelOp,     EvtFreeRTOSTimersNo, 0x04U)
 #define EvtFreeRTOSTimers_PendFuncCall                    EventID(EventLevelOp,     EvtFreeRTOSTimersNo, 0x05U)
 #define EvtFreeRTOSTimers_PendFuncCallFromIsr             EventID(EventLevelOp,     EvtFreeRTOSTimersNo, 0x06U)
+#define EvtFreeRTOSTimers_TimerNew                        EventID(EventLevelAPI,    EvtFreeRTOSTimersNo, 0x30U)
+#define EvtFreeRTOSTimers_TimerNew_Detail                 EventID(EventLevelDetail, EvtFreeRTOSTimersNo, 0x31U)
 
 /* Event IDs for "FreeRTOS EventGroups" */
 #define EvtFreeRTOSEventGroups_EventGroupCreate           EventID(EventLevelOp,     EvtFreeRTOSEventGroupsNo, 0x00U)
@@ -115,6 +121,8 @@
 #define EvtFreeRTOSEventGroups_EventGroupSetBits          EventID(EventLevelOp,     EvtFreeRTOSEventGroupsNo, 0x08U)
 #define EvtFreeRTOSEventGroups_EventGroupSetBitsFromIsr   EventID(EventLevelOp,     EvtFreeRTOSEventGroupsNo, 0x09U)
 #define EvtFreeRTOSEventGroups_EventGroupDelete           EventID(EventLevelOp,     EvtFreeRTOSEventGroupsNo, 0x0AU)
+#define EvtFreeRTOSEventGroups_EventGroupNew              EventID(EventLevelAPI,    EvtFreeRTOSEventGroupsNo, 0x30U)
+#define EvtFreeRTOSEventGroups_EventGroupNew_Detail       EventID(EventLevelDetail, EvtFreeRTOSEventGroupsNo, 0x31U)
 
 /* Event IDs for "FreeRTOS Heap" */
 #define EvtFreeRTOSHeap_Malloc                            EventID(EventLevelOp,     EvtFreeRTOSHeapNo, 0x00U)
@@ -124,6 +132,21 @@
 
 
 /* Tasks */
+
+#if (!defined(EVR_FREERTOS_DISABLE) && !defined(traceTASK_NEW_DISABLE))
+void EvrFreeRTOSTasks_TaskNew (osThreadFunc_t func, void *argument, const osThreadAttr_t *attr) {
+#if defined(RTE_Compiler_EventRecorder)
+	EventRecord4(EvtFreeRTOSTasks_TaskNew, (uint32_t)func, (uint32_t)argument, (uint32_t)attr, 0U);
+	if (attr != NULL) {
+		EventRecordData(EvtFreeRTOSTasks_TaskNew_Detail, attr, sizeof(osThreadAttr_t));
+	}
+#else
+	(void)func;
+	(void)argument;
+	(void)attr;
+#endif
+}
+#endif
 
 #if (!defined(EVR_FREERTOS_DISABLE) && !defined(traceTASK_CREATE_DISABLE))
 void EvrFreeRTOSTasks_TaskCreate (/*TCB_t*/void *pxNewTCB) {
@@ -395,6 +418,21 @@ void EvrFreeRTOSTasks_TaskNotifyGiveFromIsr (/*TCB_t*/void *xTaskToNotify, uint3
 
 /* Queue */
 
+#if (!defined(EVR_FREERTOS_DISABLE) && !defined(traceQUEUE_NEW_DISABLE))
+void EvrFreeRTOSQueue_QueueNew (uint32_t msg_count, uint32_t msg_size, const osMessageQueueAttr_t *attr) {
+#if defined(RTE_Compiler_EventRecorder)
+	EventRecord4(EvtFreeRTOSQueue_QueueNew, msg_count, msg_size, (uint32_t)attr, 0U);
+	if (attr != NULL) {
+		EventRecordData(EvtFreeRTOSQueue_QueueNew_Detail, attr, sizeof(osMemoryPoolAttr_t));
+	}
+#else
+	(void)msg_count;
+	(void)msg_size;
+	(void)attr;
+#endif
+}
+#endif
+
 #if (!defined(EVR_FREERTOS_DISABLE) && !defined(traceQUEUE_CREATE_DISABLE))
 void EvrFreeRTOSQueue_QueueCreate (/*Queue_t*/void *pxQueue) {
 #if defined(RTE_Compiler_EventRecorder)
@@ -645,6 +683,22 @@ void EvrFreeRTOSQueue_BlockingOnQueueSend (/*Queue_t*/void *pxQueue) {
 
 /* Timers */
 
+#if (!defined(EVR_FREERTOS_DISABLE) && !defined(traceTIMER_NEW_DISABLE))
+void EvrFreeRTOSTimers_TimerNew (osTimerFunc_t func, osTimerType_t type, void *argument, const osTimerAttr_t *attr) {
+#if defined(RTE_Compiler_EventRecorder)
+	EventRecord4(EvtFreeRTOSTimers_TimerNew, (uint32_t)func, (uint32_t)type, (uint32_t)argument, (uint32_t)attr);
+	if (attr != NULL) {
+		EventRecordData(EvtFreeRTOSTimers_TimerNew_Detail, attr, sizeof(osTimerAttr_t));
+	}
+#else
+	(void)func;
+	(void)type;
+	(void)argument;
+	(void)attr;
+#endif
+}
+#endif
+
 #if (!defined(EVR_FREERTOS_DISABLE) && !defined(traceTIMER_CREATE_DISABLE))
 void EvrFreeRTOSTimers_TimerCreate (/*Timer_t*/void *pxNewTimer) {
 #if defined(RTE_Compiler_EventRecorder)
@@ -726,6 +780,19 @@ void EvrFreeRTOSTimers_PendFuncCallFromIsr (/*PendedFunction_t*/void *pxFunction
 
 
 /* Event Groups */
+
+#if (!defined(EVR_FREERTOS_DISABLE) && !defined(traceEVENT_GROUP_CREATE_DISABLE))
+void EvrFreeRTOSEventGroups_EventGroupNew (const osEventFlagsAttr_t *attr) {
+#if defined(RTE_Compiler_EventRecorder)
+	EventRecord2(EvtFreeRTOSEventGroups_EventGroupNew, (uint32_t)attr, 0U);
+	if (attr != NULL) {
+		EventRecordData(EvtFreeRTOSEventGroups_EventGroupNew_Detail, attr, sizeof(osEventFlagsAttr_t));
+	}
+#else
+	(void)attr;
+#endif
+}
+#endif
 
 #if (!defined(EVR_FREERTOS_DISABLE) && !defined(traceEVENT_GROUP_CREATE_DISABLE))
 void EvrFreeRTOSEventGroups_EventGroupCreate (/*EventGroup_t*/void *pxEventGroup) {

--- a/CMSIS/RTOS2/FreeRTOS/Source/freertos_evr.c
+++ b/CMSIS/RTOS2/FreeRTOS/Source/freertos_evr.c
@@ -423,7 +423,7 @@ void EvrFreeRTOSQueue_QueueNew (uint32_t msg_count, uint32_t msg_size, const osM
 #if defined(RTE_Compiler_EventRecorder)
 	EventRecord4(EvtFreeRTOSQueue_QueueNew, msg_count, msg_size, (uint32_t)attr, 0U);
 	if (attr != NULL) {
-		EventRecordData(EvtFreeRTOSQueue_QueueNew_Detail, attr, sizeof(osMemoryPoolAttr_t));
+		EventRecordData(EvtFreeRTOSQueue_QueueNew_Detail, attr, sizeof(osMessageQueueAttr_t));
 	}
 #else
 	(void)msg_count;


### PR DESCRIPTION
Looking at how RTX5 uses initial (API-level) calls for many calls, I have added a suggestion on the most important functions, i.e. the "xxNew" calls.

I currently don't have any development environment for this set up so there might be a few minor compilation issues, but I hope that the code is clear and understandable.

This pull request is created after a discussion with Robert Rostohar.