### PR TITLE
Update cmsis_os2.c

### DIFF
--- a/CMSIS/RTOS2/FreeRTOS/Source/cmsis_os2.c
+++ b/CMSIS/RTOS2/FreeRTOS/Source/cmsis_os2.c
@@ -386,7 +386,9 @@ osThreadId_t osThreadNew (osThreadFunc_t func, void *argument, const osThreadAtt
       }
 
       if (attr->stack_size > 0U) {
-        stack = attr->stack_size;
+        stack = attr->stack_size / sizeof(StackType_t);
+        // in freeRTOS Stack is not in Bytes, but in sizeof(StackType_t) which is 4 in this case.
+        // look here http://www.freertos.org/a00125.html at parameter usStackDepth in xTaskCreate
       }
 
       if ((attr->cb_mem    != NULL) && (attr->cb_size    >= sizeof(StaticTask_t)) &&


### PR DESCRIPTION
FreeRTOS allocates 4 Times more Stack for its Threads than Keil RTX because FreeRTOS uses Stack Size in numbers of StackType_t, which is defined as uint32_t in portmacro.h and Keil RTX and the CMSIS API use Stack Size in Bytes.