### PR TITLE
Fixes to osDelayUntil

### DIFF
--- a/CMSIS/RTOS2/FreeRTOS/Source/cmsis_os2.c
+++ b/CMSIS/RTOS2/FreeRTOS/Source/cmsis_os2.c
@@ -831,7 +831,7 @@ osStatus_t osDelay (uint32_t ticks) {
 }
 
 osStatus_t osDelayUntil (uint32_t ticks) {
-  TickType_t tcnt;
+  TickType_t tcnt, delay;
   osStatus_t stat;
 
   if (IS_IRQ()) {
@@ -840,8 +840,12 @@ osStatus_t osDelayUntil (uint32_t ticks) {
   else {
     stat = osOK;
     tcnt = xTaskGetTickCount();
+    delay = (TickType_t)ticks - tcnt;
 
-    vTaskDelayUntil (&tcnt, (TickType_t)(ticks - tcnt));
+    /* check if target tick has not expired */
+    if(delay && 0 == (delay >> (8 * sizeof(TickType_t) - 1)){
+      vTaskDelayUntil (&tcnt, delay));
+    }
   }
 
   return (stat);

--- a/CMSIS/RTOS2/FreeRTOS/Source/cmsis_os2.c
+++ b/CMSIS/RTOS2/FreeRTOS/Source/cmsis_os2.c
@@ -843,8 +843,13 @@ osStatus_t osDelayUntil (uint32_t ticks) {
     delay = (TickType_t)ticks - tcnt;
 
     /* check if target tick has not expired */
-    if(delay && 0 == (delay >> (8 * sizeof(TickType_t) - 1)){
+    if(delay && 0 == (delay >> (8 * sizeof(TickType_t) - 1))){
       vTaskDelayUntil (&tcnt, delay));
+    }
+    else
+    {
+      /* No delay or already expired */
+      stat = osErrorParameter;
     }
   }
 


### PR DESCRIPTION
This fix addresses two use cases:
1. FreeRTOS debug build assert when pass zero as a second parameter to vTaskDelayUntil.
2. Very very long delay if we pass in target tick which already has expired (in a past)