### PR TITLE
osEventFlagsWait: Fix flag comparison

### DIFF
--- a/CMSIS/RTOS2/FreeRTOS/Source/cmsis_os2.c
+++ b/CMSIS/RTOS2/FreeRTOS/Source/cmsis_os2.c
@@ -1181,7 +1181,7 @@ uint32_t osEventFlagsWait (osEventFlagsId_t ef_id, uint32_t flags, uint32_t opti
     rflags = xEventGroupWaitBits (hEventGroup, (EventBits_t)flags, exit_clr, wait_all, (TickType_t)timeout);
 
     if (options & osFlagsWaitAll) {
-      if (flags != rflags) {
+      if ((flags & rflags) != flags) {
         if (timeout > 0U) {
           rflags = (uint32_t)osErrorTimeout;
         } else {


### PR DESCRIPTION
Fixed group flags comparison, when waiting on all flags (osFlagsWaitAll)
Previous implementation invokes fail every time, when other flags (those, we don't wait for) are set
This fix only compares flags specified to wait for, as API docs suggests