### PR TITLE
Made default Stack Overflow hook fail if configASSERT is defined

### DIFF
--- a/CMSIS/RTOS2/FreeRTOS/Source/cmsis_os2.c
+++ b/CMSIS/RTOS2/FreeRTOS/Source/cmsis_os2.c
@@ -2351,6 +2351,7 @@ __WEAK void vApplicationDaemonTaskStartupHook (void){}
 __WEAK void vApplicationStackOverflowHook (TaskHandle_t xTask, signed char *pcTaskName) {
   (void)xTask;
   (void)pcTaskName;
+  configASSERT(0);
 }
 #endif
 


### PR DESCRIPTION
I believe that the default implementation should fail if the user defines configASSERT. I believe this is a reasonable addition, given the fact configCHECK_FOR_STACK_OVERFLOW is already enabled by default. I hope it could save someone a lot of headache - as it happened to me when I overlooked my stack overflowing.