### PR TITLE
Task should be not blocked if flag which are we waiting for has been already set 

### DIFF
--- a/CMSIS/RTOS2/FreeRTOS/Source/cmsis_os2.c
+++ b/CMSIS/RTOS2/FreeRTOS/Source/cmsis_os2.c
@@ -997,6 +997,7 @@ uint32_t osThreadFlagsWait (uint32_t flags, uint32_t options, uint32_t timeout) 
   uint32_t clear;
   TickType_t t0, td, tout;
   BaseType_t rval;
+  BaseType_t notify = pdFALSE;
 
   if (IRQ_Context() != 0U) {
     rflags = (uint32_t)osErrorISR;
@@ -1021,6 +1022,11 @@ uint32_t osThreadFlagsWait (uint32_t flags, uint32_t options, uint32_t timeout) 
       if (rval == pdPASS) {
         rflags &= flags;
         rflags |= nval;
+
+        if(rflags & ~flags)
+        {
+        	notify = pdTRUE;
+        }
 
         if ((options & osFlagsWaitAll) == osFlagsWaitAll) {
           if ((flags & rflags) == flags) {
@@ -1061,6 +1067,16 @@ uint32_t osThreadFlagsWait (uint32_t flags, uint32_t options, uint32_t timeout) 
       }
     }
     while (rval != pdFAIL);
+  }
+
+  if(notify == pdTRUE)
+  {
+	  TaskHandle_t hTask = xTaskGetCurrentTaskHandle();
+
+	  if(xTaskNotify(hTask, 0, eNoAction) != pdPASS)
+	  {
+		  rflags = osError;
+	  }
   }
 
   /* Return flags before clearing */


### PR DESCRIPTION
Without changes: 

```
void TestTask(void *argument)
{
  /* Infinite loop */
  for(;;)
  {
	uint32_t flags = 0;
	osThreadFlagsSet(testTaskHandle, 1<<0);
	flags = osThreadFlagsWait(1<<0, osFlagsWaitAny, osWaitForever );
        osDelay(1);
       osThreadFlagsSet(testTaskHandle, 1<<0);
       osThreadFlagsSet(testTaskHandle, 1<<1);
       flags = osThreadFlagsWait(1<<0, osFlagsWaitAny, osWaitForever );
       osDelay(1);
       flags = osThreadFlagsWait(1<<1, osFlagsWaitAny, osWaitForever ); // task is blocked here even though 1<<1 flag has been 
      // already set
      osDelay(1);
  }
}
```
To be more  consistent in the way of handling Flags (whether Thread Flags or Event Flags is used) osThreadFlagsWait should not   block a task when flag which we are waitng for has been already set. For instance, the same code but using Event Flags

void TestTask(void *argument)
{
 osEventFlagsId_t evt_id = osEventFlagsNew(NULL);

 for(;;)
 {
	uint32_t flags = 0;
	osEventFlagsSet(evt_id, 1<<0);
	flags = osEventFlagsWait(evt_id, 1<<0, osFlagsWaitAny, osWaitForever );
        osDelay(1);
        osEventFlagsSet(evt_id, 1<<0);
        osEventFlagsSet(evt_id, 1<<1);
        flags = osEventFlagsWait(evt_id, 1<<0, osFlagsWaitAny, osWaitForever );
        osDelay(1);
        flags = osEventFlagsWait(evt_id, 1<<1, osFlagsWaitAny, osWaitForever ); // task is not blocked, value 2 is returned
        osDelay(1);
 }
}

When osThreadFlagsWait waits only for  (1<<0) flag but (1<<1) flag is also set then inside FreeRTOS xTaskNotifyWait function notification state is marked as taskNOT_WAITING_NOTIFICATION. 
When next osThreadFlagsWait waits for  (1<<1)  flag, task goes to BLOCKED state even though  (1<<1)  flag is actually set and task's notification value is  2 ( 1<<1) but task's notification state is taskNOT_WAITING_NOTIFICATION.

To resolve this issue task's notification state should be marked as taskNOTIFICATION_RECEIVED again after previous  osThreadFlagsWait.



