### PR TITLE
Fix RTOS2 priority value mapping (#96)

### DIFF
--- a/ARM.CMSIS-FreeRTOS.pdsc
+++ b/ARM.CMSIS-FreeRTOS.pdsc
@@ -13,6 +13,7 @@
       Active development...
       - Add support for processor affinity to CMSIS-RTOS2 wrapper
       - Add memory allocation configuration options to FreeRTOSConfig.h
+      - Corrected task priority mapping, FreeRTOS priority is now osPriority_t-1
       - CMSIS-RTOS2 requires CMSIS:OS Tick component
       - Drop support for Arm Compiler 5
       - Drop support for CMSIS-RTOS1 API

--- a/CMSIS/RTOS2/FreeRTOS/Source/cmsis_os2.c
+++ b/CMSIS/RTOS2/FreeRTOS/Source/cmsis_os2.c
@@ -582,7 +582,7 @@ osThreadId_t osThreadNew (osThreadFunc_t func, void *argument, const osThreadAtt
                                                      name,
                                                      stack,
                                                      argument,
-                                                     prio,
+                                                     prio - 1U,
                                      (StackType_t  *)attr->stack_mem,
                                      (StaticTask_t *)attr->cb_mem);
         #else
@@ -590,7 +590,7 @@ osThreadId_t osThreadNew (osThreadFunc_t func, void *argument, const osThreadAtt
                                                                 name,
                                                                 stack,
                                                                 argument,
-                                                                prio,
+                                                                prio - 1U,
                                                 (StackType_t  *)attr->stack_mem,
                                                 (StaticTask_t *)attr->cb_mem,
                                                                 core_aff);
@@ -605,7 +605,7 @@ osThreadId_t osThreadNew (osThreadFunc_t func, void *argument, const osThreadAtt
                                                      name,
                              (configSTACK_DEPTH_TYPE)stack,
                                                      argument,
-                                                     prio,
+                                                     prio - 1U,
                                                      &hTask) != pdPASS) {
               hTask = NULL;
             }
@@ -614,7 +614,7 @@ osThreadId_t osThreadNew (osThreadFunc_t func, void *argument, const osThreadAtt
                                                                 name,
                                         (configSTACK_DEPTH_TYPE)stack,
                                                                 argument,
-                                                                prio,
+                                                                prio - 1U,
                                                                 core_aff,
                                                                 &hTask) != pdPASS) {
               hTask = NULL;
@@ -722,7 +722,7 @@ osStatus_t osThreadSetPriority (osThreadId_t thread_id, osPriority_t priority) {
   }
   else {
     stat = osOK;
-    vTaskPrioritySet (hTask, (UBaseType_t)priority);
+    vTaskPrioritySet (hTask, (UBaseType_t)priority - 1U);
   }
 
   /* Return execution status */
@@ -739,7 +739,7 @@ osPriority_t osThreadGetPriority (osThreadId_t thread_id) {
   if ((IRQ_Context() != 0U) || (hTask == NULL)) {
     prio = osPriorityError;
   } else {
-    prio = (osPriority_t)((int32_t)uxTaskPriorityGet (hTask));
+    prio = (osPriority_t)(uxTaskPriorityGet (hTask) + 1U);
   }
 
   /* Return current thread priority */


### PR DESCRIPTION
- FreeRTOS handles priorities from 0 to configMAX_PRIORITIES-1
- RTOS2 defines priorities from 1(osPriorityIdle) to osPriorityISR(56)

- Till now RTOS2 passed priorities 1:1 to FreeRTOS, i.e. FreeRTOS priority matched osPriority_t.
  This commit changes priority mapping: FreeRTOS priority is now (osPriority_t - 1).