### PR TITLE
Update GitHub Actions runner to ubuntu-22.04

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: ".github/workflows"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   pack:
     name: Generate pack
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,9 +10,9 @@ on:
 jobs:
   pack:
     name: Generate pack
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -23,7 +23,7 @@ jobs:
 
       - uses: Open-CMSIS-Pack/gen-pack-action@main
         with:
-          doxygen-version: 1.9.2                                  # default
+          doxygen-version: 1.9.6                                  # default
           packchk-version: 1.3.95                                 # default
           gen-doc-script: ./DoxyGen/gen_doc.sh                    # skipped by default
           check-links-script: ./DoxyGen/check_links.sh            # skipped by default

--- a/.github/workflows/cmsis_rv2.yaml
+++ b/.github/workflows/cmsis_rv2.yaml
@@ -57,7 +57,7 @@ jobs:
       - name: Install system packages
         run: |
           sudo add-apt-repository ppa:deadsnakes/ppa
-          sudo apt-get install libpython3.9 libtinfo5
+          sudo apt-get install libpython3.9 libtinfo6
 
       - name: Python requirements
         run: |

--- a/.github/workflows/cmsis_rv2.yaml
+++ b/.github/workflows/cmsis_rv2.yaml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         compiler: [AC6, GCC, Clang]
     
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout CMSIS-FreeRTOS
@@ -130,7 +130,7 @@ jobs:
 
   publish-test-results:
     needs: [build-and-run]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     if: github.event_name == 'pull_request'
 
     env:

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -30,17 +30,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v5
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           # Upload entire repository
           path: '.'
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v4

--- a/DoxyGen/gen_doc.sh
+++ b/DoxyGen/gen_doc.sh
@@ -5,7 +5,7 @@
 #
 # Pre-requisites:
 # - bash shell (for Windows: install git for Windows)
-# - doxygen 1.9.2
+# - doxygen 1.9.6
 
 set -o pipefail
 
@@ -14,7 +14,7 @@ REQUIRED_GEN_PACK_LIB="0.6.0"
 
 DIRNAME=$(dirname $(readlink -f $0))
 DOXYGEN=$(which doxygen 2>/dev/null)
-REQ_DXY_VERSION="1.9.2"
+REQ_DXY_VERSION="1.9.6"
 
 if [[ ! -f "${DOXYGEN}" ]]; then
     echo "Doxygen not found!" >&2


### PR DESCRIPTION
This PR updates the GitHub Actions runner from ubuntu-20.04 to ubuntu-22.04.