### PR TITLE
Typo causes Cortex-M35 to be enabled instead of Cortex-M33

### DIFF
--- a/ARM.CMSIS-FreeRTOS.pdsc
+++ b/ARM.CMSIS-FreeRTOS.pdsc
@@ -470,7 +470,7 @@
     </condition>
     <condition id="CM35P_TZ_IAR">
       <description>Cortex-M35P processor based device with TrustZone for the IAR Compiler</description>
-      <require condition="CM33_TZ"/>
+      <require condition="CM35P_TZ"/>
       <require condition="IAR"/>
     </condition>
 


### PR DESCRIPTION
This solves IAR issue EWARM-13560.