### PR TITLE
Replaced references

### DIFF
--- a/CMSIS/RTOS2/FreeRTOS/Examples/README.md
+++ b/CMSIS/RTOS2/FreeRTOS/Examples/README.md
@@ -55,7 +55,7 @@ Once the context and projects are selected one can build them by selecting "Buil
 
 ## Build via command line
 
-> - See [CMSIS-Toolbox documentation](https://github.com/Open-CMSIS-Pack/cmsis-toolbox/blob/main/docs/README.md)
+> - See [CMSIS-Toolbox documentation](https://open-cmsis-pack.github.io/cmsis-toolbox/)
 >   to learn more about CMSIS Solution project build and management tools.
 
 To build the project via command line one can use the following command syntax:

--- a/Source/README.md
+++ b/Source/README.md
@@ -14,7 +14,7 @@ application projects.  That way you will have the correct FreeRTOS source files
 included, and the correct include paths configured. Once a demo application is
 building and executing you can remove the demo application files, and start to
 add in your own application source files.  See the
-[FreeRTOS Kernel Quick Start Guide](https://www.FreeRTOS.org/FreeRTOS-quick-start-guide.html)
+[FreeRTOS Kernel Quick Start Guide](https://freertos.org/Documentation/01-FreeRTOS-quick-start/01-Beginners-guide/02-Quick-start-guide)
 for detailed instructions and other useful links.
 
 Additionally, for FreeRTOS kernel feature information refer to the


### PR DESCRIPTION
Replaced references to https://github.com/Open-CMSIS-Pack/cmsis-toolbox/... to https://open-cmsis-pack.github.io/cmsis-toolbox/ a.o
[Issue 248](https://github.com/Open-CMSIS-Pack/cmsis-toolbox/issues/248)