### PR TITLE
add function to convert osStatus_t to human-readable string

### DIFF
--- a/CMSIS/RTOS2/FreeRTOS/Source/cmsis_os2.c
+++ b/CMSIS/RTOS2/FreeRTOS/Source/cmsis_os2.c
@@ -1558,9 +1558,9 @@ uint32_t osEventFlagsSet (osEventFlagsId_t ef_id, uint32_t flags) {
       rflags  = xEventGroupGetBitsFromISR (hEventGroup);
       rflags |= flags;
       portYIELD_FROM_ISR (yield);
+    }
+  #endif
   }
-#endif
-}
   else {
     rflags = xEventGroupSetBits (hEventGroup, (EventBits_t)flags);
   }

--- a/CMSIS/RTOS2/FreeRTOS/Source/cmsis_os2.c
+++ b/CMSIS/RTOS2/FreeRTOS/Source/cmsis_os2.c
@@ -2946,6 +2946,27 @@ static void FreeBlock (MemPool_t *mp, void *block) {
 #endif /* FREERTOS_MPOOL_H_ */
 /*---------------------------------------------------------------------------*/
 
+/**
+ * Convert osStatus_t to a human-readable string.
+ */
+const char* osStatusToString(osStatus_t status) {
+    switch (status) {
+        case osOK:                     return "osOK";
+        case osError:                  return "osError";
+        case osErrorTimeout:           return "osErrorTimeout";
+        case osErrorResource:          return "osErrorResource";
+        case osErrorParameter:         return "osErrorParameter";
+        case osErrorNoMemory:          return "osErrorNoMemory";
+        case osErrorISR:               return "osErrorISR";
+        case osErrorISRRecursive:      return "osErrorISRRecursive";
+        case osErrorPriority:          return "osErrorPriority";
+        case osErrorTimeoutResource:   return "osErrorTimeoutResource";
+        case osErrorISRQueueFull:      return "osErrorISRQueueFull";
+        case osErrorStackOverflow:     return "osErrorStackOverflow";
+        default:                       return "Unknown osStatus_t";
+    }
+}
+
 /* Callback function prototypes */
 extern void vApplicationIdleHook (void);
 extern void vApplicationMallocFailedHook (void);


### PR DESCRIPTION
**Summary**
This PR introduces a new utility function, osStatusToString, to convert osStatus_t values into human-readable strings.

**Changes**
Added the osStatusToString function to map osStatus_t values to corresponding string representations.


**Benefits**:
Useful for logging errors in a readable format.

**Usage Example**:
```
osStatus_t status = osKernelInitialize();
printf("Kernel initialization status: %s\n", osStatusToString(status));
```

**NOTE**
I only added the function implementation but no declaration as I didn't find the **cmsis_os2.h**