### PR TITLE
remove redundant condition from name assignment and put NULL assignme…

### DIFF
--- a/CMSIS/RTOS2/FreeRTOS/Source/cmsis_os2.c
+++ b/CMSIS/RTOS2/FreeRTOS/Source/cmsis_os2.c
@@ -534,13 +534,12 @@ osThreadId_t osThreadNew (osThreadFunc_t func, void *argument, const osThreadAtt
     stack = configMINIMAL_STACK_SIZE;
     prio  = (UBaseType_t)osPriorityNormal;
 
-    name = NULL;
     mem  = -1;
 
     if (attr != NULL) {
-      if (attr->name != NULL) {
-        name = attr->name;
-      }
+      /* No need to check if NULL, NULL is OK */
+      name = attr->name;
+
       if (attr->priority != osPriorityNone) {
         prio = (UBaseType_t)attr->priority;
       }
@@ -576,6 +575,7 @@ osThreadId_t osThreadNew (osThreadFunc_t func, void *argument, const osThreadAtt
     }
     else {
       mem = 0;
+      name = NULL;
     }
 
     if (mem == 1) {
@@ -1281,12 +1281,10 @@ osTimerId_t osTimerNew (osTimerFunc_t func, osTimerType_t type, void *argument, 
       }
 
       mem  = -1;
-      name = NULL;
 
       if (attr != NULL) {
-        if (attr->name != NULL) {
-          name = attr->name;
-        }
+        /* No need to check if NULL, NULL is OK */
+        name = attr->name;
 
         if ((attr->cb_mem != NULL) && (attr->cb_size >= sizeof(StaticTimer_t))) {
           /* The memory for control block is provided, use static object */
@@ -1301,6 +1299,7 @@ osTimerId_t osTimerNew (osTimerFunc_t func, osTimerType_t type, void *argument, 
       }
       else {
         mem = 0;
+        name = NULL;
       }
       /* Store callback memory dynamic allocation flag */
       callb = (TimerCallback_t *)((uint32_t)callb | callb_dyn);
@@ -2482,14 +2481,12 @@ osMemoryPoolId_t osMemoryPoolNew (uint32_t block_count, uint32_t block_size, con
     mp = NULL;
     sz = MEMPOOL_ARR_SIZE (block_count, block_size);
 
-    name = NULL;
     mem_cb = -1;
     mem_mp = -1;
 
     if (attr != NULL) {
-      if (attr->name != NULL) {
-        name = attr->name;
-      }
+      /* No need to check if NULL, NULL is OK */
+      name = attr->name;
 
       if ((attr->cb_mem != NULL) && (attr->cb_size >= sizeof(MemPool_t))) {
         /* Static control block is provided */
@@ -2521,6 +2518,7 @@ osMemoryPoolId_t osMemoryPoolNew (uint32_t block_count, uint32_t block_size, con
       /* Attributes not provided, allocate memory on heap */
       mem_cb = 0;
       mem_mp = 0;
+      name = NULL;
     }
 
     if (mem_cb == 0) {


### PR DESCRIPTION
The if statement is redundant because it is OK to put NULL, and the NULL assignment is relevant just in cases there is no attribute, in case there is attributes we anyway will overwrite it with the name in the attributes (or with the NULL in the attributes)