### PR TITLE
in new mem pool ensure given memory valid before using it

### DIFF
--- a/CMSIS/RTOS2/FreeRTOS/Source/cmsis_os2.c
+++ b/CMSIS/RTOS2/FreeRTOS/Source/cmsis_os2.c
@@ -2530,6 +2530,8 @@ osMemoryPoolId_t osMemoryPoolNew (uint32_t block_count, uint32_t block_size, con
     }
 
     if (mp != NULL) {
+      mp->mem_arr = NULL;
+
       /* Create a semaphore (max count == initial count == block_count) */
       #if (configSUPPORT_STATIC_ALLOCATION == 1)
         mp->sem = xSemaphoreCreateCountingStatic (block_count, block_count, &mp->mem_sem);


### PR DESCRIPTION
In new memory pool creation, the mem variables are checked against 0 but not against 1.
Hence when something was not valid (mem is -1) still the memory is in use. This may cause writing in space over the given control block.

The logic is correct in all other places control block is in use except here.

Code to reproduce the issue:
```
int main()
{
    uint8_t mem1[100];
    uint8_t mem2[100];
    memset(mem1, 0, 100);
    memset(mem2, 0, 100);
    osMemoryPoolAttr_t attr;
    attr.cb_mem = mem1;
    attr.mp_mem = mem2;
    attr.cb_size = 4;
    attr.mp_size = 4;
    osMemoryPoolNew(4, 4, &attr);
    for(int i = 4; i < 100; i++)
    {
        if(mem1[i]!=0)
        {
            printf("someone touched mem1 in index %d\n", i);
        }
        if(mem2[i]!=0)
        {
            printf("someone touched mem2 in index %d\n", i);
        }
    }
    return 0;
}
```