### PR TITLE
Use uxQueueMessagesWaitingFromISR in function osMessageQueueGetSpace

### DIFF
--- a/CMSIS/RTOS2/FreeRTOS/Source/cmsis_os2.c
+++ b/CMSIS/RTOS2/FreeRTOS/Source/cmsis_os2.c
@@ -2386,7 +2386,7 @@ uint32_t osMessageQueueGetSpace (osMessageQueueId_t mq_id) {
   else if (IRQ_Context() != 0U) {
     isrm = taskENTER_CRITICAL_FROM_ISR();
 
-    space = uxQueueGetQueueLength (hQueue) - uxQueueMessagesWaiting (hQueue);
+    space = uxQueueGetQueueLength (hQueue) - uxQueueMessagesWaitingFromISR (hQueue);
 
     taskEXIT_CRITICAL_FROM_ISR(isrm);
   }


### PR DESCRIPTION
A call to uxQueueMessagesWaiting from ISR context triggers configASSERT. Therefore the call has been replaced with uxQueueMessagesWaitingFromISR.

There is currently no ISR safe alternative to uxQueueGetQueueLength - this call has not been replaced as is expected to work without triggering an assertion.