### PR TITLE
Fix KERNEL_VERSION macro to use addition instead of bitwise OR

### DIFF
--- a/CMSIS/RTOS2/FreeRTOS/Source/cmsis_os2.c
+++ b/CMSIS/RTOS2/FreeRTOS/Source/cmsis_os2.c
@@ -85,8 +85,8 @@
 #define EVENT_FLAGS_INVALID_BITS  (~((1UL << MAX_BITS_EVENT_GROUPS) - 1U))
 
 /* Kernel version and identification string definition (major.minor.rev: mmnnnrrrr dec) */
-#define KERNEL_VERSION            (((uint32_t)tskKERNEL_VERSION_MAJOR * 10000000UL) | \
-                                   ((uint32_t)tskKERNEL_VERSION_MINOR *    10000UL) | \
+#define KERNEL_VERSION            (((uint32_t)tskKERNEL_VERSION_MAJOR * 10000000UL) + \
+                                   ((uint32_t)tskKERNEL_VERSION_MINOR *    10000UL) + \
                                    ((uint32_t)tskKERNEL_VERSION_BUILD *        1UL))
 
 #define KERNEL_ID                 ("FreeRTOS " tskKERNEL_VERSION_NUMBER)


### PR DESCRIPTION
## Problem
The `KERNEL_VERSION` macro in `cmsis_os2.c` uses bitwise OR (`|`) to combine version components, which causes incorrect version encoding. For example, with CMSIS-FreeRTOS v11.1.0, `osKernelGetInfo()` returns `11.0.16` instead of the expected `11.1.0`.

## Solution
Changed the macro to use addition (`+`) instead of bitwise OR to properly encode the version in the format `mmnnnrrrr` (decimal).

## Changes
- Modified `KERNEL_VERSION` macro in `CMSIS/RTOS2/FreeRTOS/Source/cmsis_os2.c`
- Replaced `|` operators with `+` operators

## Testing
This fix ensures that `osVersion_t::api` and `osVersion_t::kernel` fields return the correct version number when calling `osKernelGetInfo()`.