### PR TITLE
Pack cache cleanup

### DIFF
--- a/.github/workflows/cmsis_rv2.yaml
+++ b/.github/workflows/cmsis_rv2.yaml
@@ -67,15 +67,12 @@ jobs:
         uses: ARM-software/cmsis-actions/vcpkg@main
         with:
           config: ./CMSIS-RTOS2_Validation/Project/vcpkg-configuration.json
-          cache: "-${{ matrix.compiler }}"
 
       - name: Activate Arm tool license
-        run: |
-          if [[ -n "${{ env.ARM_UBL_ACTIVATION_CODE }}" ]]; then
-            armlm activate --code ${{ env.ARM_UBL_ACTIVATION_CODE }}
-          else
-            armlm activate --server https://mdk-preview.keil.arm.com --product KEMDK-COM0
-          fi
+        uses: ARM-software/cmsis-actions/armlm@v1
+        with:
+          server: https://mdk-preview.keil.arm.com
+          product: KEMDK-COM0
 
       - name: Register local packs
         run: |

--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -40,8 +40,10 @@ jobs:
           config: ./CMSIS/RTOS2/FreeRTOS/Examples/vcpkg-configuration.json
 
       - name: Activate Arm tool license
-        run: |
-          armlm activate --server https://mdk-preview.keil.arm.com --product KEMDK-COM0
+        uses: ARM-software/cmsis-actions/armlm@v1
+        with:
+          server: https://mdk-preview.keil.arm.com
+          product: KEMDK-COM0
 
       - uses: ammaraskar/gcc-problem-matcher@master
 


### PR DESCRIPTION
The size of the pack cache is ~15MB. Without using the registered cache, it should be fairly fast.