### PR TITLE
fix: include CMSIS device header unconditionally in freertos_os2.h

### DIFF
--- a/CMSIS/RTOS2/FreeRTOS/Include/freertos_evr.h
+++ b/CMSIS/RTOS2/FreeRTOS/Include/freertos_evr.h
@@ -1,5 +1,5 @@
 /* --------------------------------------------------------------------------
- * Copyright (c) 2013-2025 Arm Limited. All rights reserved.
+ * Copyright 2013-2026 Arm Limited and/or its affiliates.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -26,7 +26,9 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+#if defined(_RTE_)
 #include "RTE_Components.h"
+#endif
 
 #if !defined(RTE_Compiler_EventRecorder) && !defined(RTE_CMSIS_View_EventRecorder)
   /* Disable debug events if Event Recorder is not used */

--- a/CMSIS/RTOS2/FreeRTOS/Include/freertos_os2.h
+++ b/CMSIS/RTOS2/FreeRTOS/Include/freertos_os2.h
@@ -36,7 +36,6 @@
 
 #include CMSIS_device_header
 
-#if defined(_RTE_)
 /* Configuration and component setup check */
 #if defined(RTE_Compiler_EventRecorder) || defined(RTE_CMSIS_View_EventRecorder)
   #if !defined(EVR_FREERTOS_DISABLE)
@@ -59,7 +58,6 @@
 #if defined(RTE_RTOS_FreeRTOS_HEAP_5)
   #define USE_FreeRTOS_HEAP_5
 #endif
-#endif /* _RTE_ */
 
 /*
   CMSIS-RTOS2 FreeRTOS image size optimization definitions.

--- a/CMSIS/RTOS2/FreeRTOS/Include/freertos_os2.h
+++ b/CMSIS/RTOS2/FreeRTOS/Include/freertos_os2.h
@@ -30,8 +30,13 @@
 
 #if defined(_RTE_)
 #include "RTE_Components.h"             // Component selection
+#elif !defined(CMSIS_device_header)
+#error "CMSIS_device_header must be defined to point to CMSIS device header"
+#endif
+
 #include CMSIS_device_header
 
+#if defined(_RTE_)
 /* Configuration and component setup check */
 #if defined(RTE_Compiler_EventRecorder) || defined(RTE_CMSIS_View_EventRecorder)
   #if !defined(EVR_FREERTOS_DISABLE)

--- a/CMSIS/RTOS2/FreeRTOS/Source/clib_os.c
+++ b/CMSIS/RTOS2/FreeRTOS/Source/clib_os.c
@@ -1,5 +1,5 @@
 /* -------------------------------------------------------------------------- 
- * Copyright (c) 2024-2025 Arm Limited. All rights reserved.
+ * Copyright 2024-2026 Arm Limited and/or its affiliates.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -26,6 +26,12 @@
 #include "FreeRTOS.h"                   // ARM.FreeRTOS::RTOS:Core
 #include "task.h"                       // ARM.FreeRTOS::RTOS:Core
 #include "semphr.h"                     // ARM.FreeRTOS::RTOS:Core
+
+#include "cmsis_compiler.h"
+
+#if defined(_RTE_)
+#include "RTE_Components.h"
+#endif
 
 /* Event Recorder initialization before entering function "main" */
 #if (defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050) && !defined(__MICROLIB))

--- a/CMSIS/RTOS2/FreeRTOS/Source/handlers.c
+++ b/CMSIS/RTOS2/FreeRTOS/Source/handlers.c
@@ -1,14 +1,5 @@
-/******************************************************************************
- * @file     irq_handler.c
- * @brief    CMSIS-FreeRTOS Interrupt Handler
- * @version  9.1.0
- * @date     11 Aug 2017
- *
- * @note
- *
- ******************************************************************************/
 /*
- * Copyright (c) 2017 Arm Limited. All rights reserved.
+ * Copyright 2017-2018, 2026 Arm Limited and/or its affiliates.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -27,7 +18,12 @@
 
 #include <stddef.h>
 
+#if defined(_RTE_)
 #include "RTE_Components.h"
+#elif !defined(CMSIS_device_header)
+#error "CMSIS_device_header must be defined to point to CMSIS device header"
+#endif
+
 #include CMSIS_device_header
 #include "irq_ctrl.h"
 


### PR DESCRIPTION
## Context

We are integrating CMSIS-FreeRTOS into a CMake-based project using the CMSIS RTOS2 adapter layer. When building with GCC via CMake (without Keil MDK), `SysTick_Handler` was silently missing from the final binary, causing the RTOS to never tick. The root cause turned out to be the device header include being gated behind a Keil-specific macro.

## Problem

In `CMSIS/RTOS2/FreeRTOS/Include/freertos_os2.h`, `#include CMSIS_device_header` is guarded by `#if defined(_RTE_)`. The `_RTE_` macro is Keil MDK-specific and is not defined when building with GCC, CMake, or other non-Keil toolchains. As a result, the CMSIS device header is never included in `cmsis_os2.c`, the `SysTick` macro is never defined, and `SysTick_Handler` inside the `#if defined(SysTick)` block is silently compiled out.

## Fix

Move `#include CMSIS_device_header` outside the `#if defined(_RTE_)` guard so it is included unconditionally. Add an `#elif !defined(CMSIS_device_header)` error guard for non-RTE builds, matching the pattern used in `os_systick.c` from [ARM-software/CMSIS_6](https://github.com/ARM-software/CMSIS_6).

## Validation

Build `cmsis_os2.c` with a GCC-based toolchain using `-DCMSIS_device_header=\"<device>.h\"` (without `-D_RTE_`) and verify:
1. Compilation succeeds.
2. `SysTick_Handler` is present in the object file.
3. Existing Keil MDK builds (with `_RTE_`) are unaffected.

## Note

`handlers.c` and `Config/FreeRTOSConfig.h` have a similar unconditional `#include "RTE_Components.h"` but are RTE-only components (Cortex-A IRQ handler / template config) and are not addressed here.

## References

- https://github.com/ARM-software/CMSIS_6/issues/200
- https://github.com/ARM-software/CMSIS_6/issues/205
- https://github.com/ARM-software/CMSIS_6/pull/206
- Fixes #185 