### PR TITLE
Change configASSERT behavior to disable interrupts instead of executing BKPT instruction

### DIFF
--- a/CMSIS/RTOS2/FreeRTOS/Config/FreeRTOSConfig.h
+++ b/CMSIS/RTOS2/FreeRTOS/Config/FreeRTOSConfig.h
@@ -320,10 +320,11 @@
 //------------- <<< end of configuration section >>> ---------------------------
 
 /* Define to trap errors during development */
-#define configASSERT(x)                           do {                \
-                                                    if ((x) == 0) {   \
-                                                      __BKPT(0);      \
-                                                    }                 \
+#define configASSERT(x)                           do {                          \
+                                                    if ((x) == 0) {             \
+                                                      taskDISABLE_INTERRUPTS(); \
+                                                      for(;;){;}                \
+                                                    }                           \
                                                   } while(0)
 
 /* Defines needed by FreeRTOS to implement CMSIS RTOS2 API. Do not change! */

--- a/CMSIS/RTOS2/FreeRTOS/Examples/App/Hello/RTE/RTOS/FreeRTOSConfig.h
+++ b/CMSIS/RTOS2/FreeRTOS/Examples/App/Hello/RTE/RTOS/FreeRTOSConfig.h
@@ -320,10 +320,11 @@
 //------------- <<< end of configuration section >>> ---------------------------
 
 /* Define to trap errors during development */
-#define configASSERT(x)                           do {                \
-                                                    if ((x) == 0) {   \
-                                                      __BKPT(0);      \
-                                                    }                 \
+#define configASSERT(x)                           do {                          \
+                                                    if ((x) == 0) {             \
+                                                      taskDISABLE_INTERRUPTS(); \
+                                                      for(;;){;}                \
+                                                    }                           \
                                                   } while(0)
 
 /* Defines needed by FreeRTOS to implement CMSIS RTOS2 API. Do not change! */

--- a/CMSIS/RTOS2/FreeRTOS/Examples/App/Hello/RTE/RTOS/FreeRTOSConfig.h.base@10.7.1
+++ b/CMSIS/RTOS2/FreeRTOS/Examples/App/Hello/RTE/RTOS/FreeRTOSConfig.h.base@10.7.1
@@ -320,10 +320,11 @@
 //------------- <<< end of configuration section >>> ---------------------------
 
 /* Define to trap errors during development */
-#define configASSERT(x)                           do {                \
-                                                    if ((x) == 0) {   \
-                                                      __BKPT(0);      \
-                                                    }                 \
+#define configASSERT(x)                           do {                          \
+                                                    if ((x) == 0) {             \
+                                                      taskDISABLE_INTERRUPTS(); \
+                                                      for(;;){;}                \
+                                                    }                           \
                                                   } while(0)
 
 /* Defines needed by FreeRTOS to implement CMSIS RTOS2 API. Do not change! */

--- a/CMSIS/RTOS2/FreeRTOS/Examples/App/TrustZone/NonSecure/RTE/RTOS/FreeRTOSConfig.h
+++ b/CMSIS/RTOS2/FreeRTOS/Examples/App/TrustZone/NonSecure/RTE/RTOS/FreeRTOSConfig.h
@@ -320,10 +320,11 @@
 //------------- <<< end of configuration section >>> ---------------------------
 
 /* Define to trap errors during development */
-#define configASSERT(x)                           do {                \
-                                                    if ((x) == 0) {   \
-                                                      __BKPT(0);      \
-                                                    }                 \
+#define configASSERT(x)                           do {                          \
+                                                    if ((x) == 0) {             \
+                                                      taskDISABLE_INTERRUPTS(); \
+                                                      for(;;){;}                \
+                                                    }                           \
                                                   } while(0)
 
 /* Defines needed by FreeRTOS to implement CMSIS RTOS2 API. Do not change! */

--- a/CMSIS/RTOS2/FreeRTOS/Examples/App/TrustZone/NonSecure/RTE/RTOS/FreeRTOSConfig.h.base@10.7.1
+++ b/CMSIS/RTOS2/FreeRTOS/Examples/App/TrustZone/NonSecure/RTE/RTOS/FreeRTOSConfig.h.base@10.7.1
@@ -320,10 +320,11 @@
 //------------- <<< end of configuration section >>> ---------------------------
 
 /* Define to trap errors during development */
-#define configASSERT(x)                           do {                \
-                                                    if ((x) == 0) {   \
-                                                      __BKPT(0);      \
-                                                    }                 \
+#define configASSERT(x)                           do {                          \
+                                                    if ((x) == 0) {             \
+                                                      taskDISABLE_INTERRUPTS(); \
+                                                      for(;;){;}                \
+                                                    }                           \
                                                   } while(0)
 
 /* Defines needed by FreeRTOS to implement CMSIS RTOS2 API. Do not change! */


### PR DESCRIPTION
Not all debuggers catch the BKPT instruction to stop execution, hence the CPU ends up in fault. New behavior aligns with FreeRTOS common practice to just disable interrupts and enter dead loop for inspection in debug session.